### PR TITLE
Remove gelf plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem 'oj', '3.11.0'
 
 # uw
 gem 'fluent-plugin-gcloud-pubsub-custom', '1.6.0'
-gem 'fluent-plugin-gelf-hs', '1.0.8'
 gem 'fluent-plugin-grafana-loki', '1.2.16'
 gem 'fluent-plugin-s3', '1.5.1'
 gem 'fluent-plugin-throttle', '0.0.5'


### PR DESCRIPTION
No longer needed, we don't run Graylog
